### PR TITLE
Fix getWaveForms indexing error

### DIFF
--- a/analysis/getWaveForms.m
+++ b/analysis/getWaveForms.m
@@ -47,6 +47,8 @@ waveFormsMean = nan(numUnits,nChInMap,wfNSamples);
 for curUnitInd=1:numUnits
     curUnitID = unitIDs(curUnitInd);
     curSpikeTimes = gwfparams.spikeTimes(gwfparams.spikeClusters==curUnitID);
+    curSpikeTimes((curSpikeTimes + gwfparams.wfWin(1)) < 1) = [];
+    curSpikeTimes((curSpikeTimes + gwfparams.wfWin(end)) > size(mmf.Data.x,2)) = [];
     curUnitnSpikes = size(curSpikeTimes,1);
     spikeTimesRP = curSpikeTimes(randperm(curUnitnSpikes));
     spikeTimeKeeps(curUnitInd,1:min([gwfparams.nWf curUnitnSpikes])) = sort(spikeTimesRP(1:min([gwfparams.nWf curUnitnSpikes])));


### PR DESCRIPTION
We updated getWaveForms to remove spikes near the start or end of the recording in order to prevent indexing errors associated with this type of spike.